### PR TITLE
Fix data engine client ignoring token env variable

### DIFF
--- a/dagshub/data_engine/client/data_client.py
+++ b/dagshub/data_engine/client/data_client.py
@@ -37,7 +37,7 @@ class DataClient:
 
     def _init_client(self):
         url = f"{self.host}/api/v1/repos/{self.repo}/data-engine/graphql"
-        auth = HTTPBearerAuth(dagshub.auth.get_token(host=self.host))
+        auth = HTTPBearerAuth(config.token or dagshub.auth.get_token(host=self.host))
         transport = RequestsHTTPTransport(url=url, auth=auth)
         client = gql.Client(transport=transport)
         return client


### PR DESCRIPTION
There is a lot of copy-pasta of this snippet around the codebase:

`dagshub.common.config.token or dagshub.auth.get_token()`

This should be refactored.
In the meantime, here's a proposed fix specifically for the new data engine code which ignored config obtained from env variables or otherwise.