### PR TITLE
Corrected tensorflow batching

### DIFF
--- a/dagshub/data_engine/client/loaders/tf.py
+++ b/dagshub/data_engine/client/loaders/tf.py
@@ -46,10 +46,18 @@ class TensorFlowDataLoader(tf.keras.utils.Sequence):
         return self.dataset.__len__() // self.batch_size
 
     def __getitem__(self, index: int) -> tf.Tensor:
-        samples = [self.dataset.__getitem__(index) for index in self.indices[index * self.batch_size : (index + 1) * self.batch_size]]
-        batch = [[] for _ in range(len(samples[0]))] # [[]] * len(samples[0]) creates lists shallowly
+        samples = [
+            self.dataset.__getitem__(index)
+            for index in self.indices[
+                index * self.batch_size : (index + 1) * self.batch_size
+            ]
+        ]
+        batch = [
+            [] for _ in range(len(samples[0]))
+        ]  # [[]] * len(samples[0]) creates lists shallowly
         for sample in samples:
-            for idx, tensor in enumerate(sample): batch[idx].append(tensor)
+            for idx, tensor in enumerate(sample):
+                batch[idx].append(tensor)
 
         return [tf.stack(column) for column in batch]
 

--- a/dagshub/data_engine/client/loaders/tf.py
+++ b/dagshub/data_engine/client/loaders/tf.py
@@ -46,8 +46,12 @@ class TensorFlowDataLoader(tf.keras.utils.Sequence):
         return self.dataset.__len__() // self.batch_size
 
     def __getitem__(self, index: int) -> tf.Tensor:
-        indices = self.indices[index * self.batch_size : (index + 1) * self.batch_size]
-        return [self.dataset.__getitem__(index) for index in indices]
+        samples = [self.dataset.__getitem__(index) for index in self.indices[index * self.batch_size : (index + 1) * self.batch_size]]
+        batch = [[] for _ in range(len(samples[0]))] # [[]] * len(samples[0]) creates lists shallowly
+        for sample in samples:
+            for idx, tensor in enumerate(sample): batch[idx].append(tensor)
+
+        return [tf.stack(column) for column in batch]
 
     def on_epoch_end(self) -> None:
         self.indices = np.arange(self.dataset.__len__())


### PR DESCRIPTION
Torch batches using: `X = (batch, *size), y = (batch, *size)`, while tensorflow uses: `z = [[batch_1], [batch_2]]`, where `batch_n = (*size)`. 

Torch does it correctly, so the behaviors are now unified. Instead of tensorflow batching being a single list with samples, it now contains the number of elements equal to the number of columns, and each column individually includes the batch's entire range of samples as part of the column tensor.

This notebook with different versions of the client can be used to evaluate both divergent and unified behaviors: https://colab.research.google.com/drive/1gmwLZWQJrjUFucxIchuTipuiu5oZ3oVy#scrollTo=rzg_NMQGfqHT