### PR TITLE
datasources.get_or_create and ds.annotate()

### DIFF
--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -38,3 +38,6 @@ quiet = bool(os.environ.get(DAGSHUB_QUIET_KEY, False))
 
 # DVC config templates
 CONFIG_GITIGNORE = "/config.local\n/tmp\n/cache"
+
+RECOMMENDED_ANNOTATE_LIMIT_KEY = "RECOMMENDED_ANNOTATE_LIMIT"
+recommended_annotate_limit = os.environ.get(RECOMMENDED_ANNOTATE_LIMIT_KEY, 1e5)

--- a/dagshub/data_engine/datasources.py
+++ b/dagshub/data_engine/datasources.py
@@ -116,4 +116,5 @@ __all__ = [
     create_from_repo,
     get_datasource,
     get,
+    get_or_create,
 ]

--- a/dagshub/data_engine/datasources.py
+++ b/dagshub/data_engine/datasources.py
@@ -59,7 +59,7 @@ def get_or_create(repo: str, name: str, path: str, revision: Optional[str] = Non
     try:
         return get_datasource(repo, name)
     except DatasourceNotFoundError:
-        return get_or_create(repo, name, path, revision)
+        return create_datasource(repo, name, path, revision)
 
 
 def create_from_bucket(repo: str, name: str, bucket_url: str) -> Datasource:

--- a/dagshub/data_engine/datasources.py
+++ b/dagshub/data_engine/datasources.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 from typing import Optional, Union, List
 
 from dagshub.common.api.repo import RepoAPI
@@ -6,8 +7,59 @@ from dagshub.data_engine.client.data_client import DataClient
 from dagshub.data_engine.client.models import DatasourceType
 from dagshub.data_engine.model.datasource import Datasource
 from dagshub.data_engine.model.datasource_state import DatasourceState
+from dagshub.data_engine.model.errors import DatasourceNotFoundError
 
 logger = logging.getLogger(__name__)
+
+
+def create_datasource(repo: str, name: str, path: str, revision: Optional[str] = None) -> Datasource:
+    """
+    Create a datasource from a path in the repo, or a storage bucket URL.
+
+    :param repo: The full repo name in <owner>/<reponame> format
+    :param name: The name of the datasource to be created
+    :param path: Either a path to a directory inside the Git/DVC repo on DagsHub, e.g. "path/to/dir"
+                 or else a URL pointing
+                 to a storage bucket which is connected to the DagsHub repo - e.g. "s3://bucketname/path/in/bucket"
+    :param revision: Only valid when using a Git/DVC path inside the DagsHub repo, not when using a bucket URL.
+                     Allows you to define the branch name where the referenced directory exists.
+                     The default repo branch is used if this is left blank.
+    :return The created datasource
+    """
+
+    parsed = urllib.parse.urlparse(path)
+
+    if parsed.scheme == "" \
+        and parsed.hostname == "" \
+        and parsed.query == "" \
+        and parsed.params == "" \
+        and parsed.fragment == "":
+        return create_from_repo(repo, name, path=parsed.path, revision=revision)
+
+    elif parsed.scheme != "" and parsed.hostname != "":
+        # Bucket URL
+        if parsed.query != "" or parsed.params != "" or parsed.fragment != "":
+            raise ValueError("Invalid bucket URL: ", path)
+        if revision != "":
+            raise ValueError("revision cannot be used together with bucket URLs")
+        return create_from_bucket(repo, name, bucket_url=path)
+
+    raise ValueError("Invalid path used, format could not be determined: ", path)
+
+
+create = create_datasource
+
+
+def get_or_create(repo: str, name: str, path: str, revision: Optional[str] = None) -> Datasource:
+    """
+    First attempts to get the repo datasource with the given name, and only if that fails,
+    invokes create_datasource with the given parameters.
+    See the docs on create_datasource for more info.
+    """
+    try:
+        return get_datasource(repo, name)
+    except DatasourceNotFoundError:
+        return get_or_create(repo, name, path, revision)
 
 
 def create_from_bucket(repo: str, name: str, bucket_url: str) -> Datasource:
@@ -45,6 +97,10 @@ def get_datasources(repo: str) -> List[Datasource]:
     return [Datasource(DatasourceState.from_gql_result(repo, source)) for source in sources]
 
 
+# Alias
+get = get_datasource
+
+
 def _create_datasource_state(repo: str, name: str, source_type: DatasourceType, path: str) -> DatasourceState:
     ds = DatasourceState(name=name, repo=repo)
     ds.source_type = source_type
@@ -54,7 +110,10 @@ def _create_datasource_state(repo: str, name: str, source_type: DatasourceType, 
 
 
 __all__ = [
+    create_datasource,
+    create,
     create_from_bucket,
     create_from_repo,
     get_datasource,
+    get,
 ]

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -310,13 +310,14 @@ class Datasource:
         """
         self.send_datapoints_to_annotation(self.all().entries)
 
-    def send_datapoints_to_annotation(self, datapoints: Union[List[Datapoint], List[Dict]],
+    def send_datapoints_to_annotation(self, datapoints: Union[List[Datapoint], QueryResult, List[Dict]],
                                       open_project=True) -> Optional[str]:
         """
         Sends datapoints to annotations in Label Studio
 
         Args:
-        datapoints : either a list of Datapoints or dicts that have "id" and "downloadurl" fields
+        datapoints : Either a list of Datapoints or dicts that have "id" and "downloadurl" fields.
+                     A QueryResult can also function as a list of Datapoint.
         open_project : specifies whether the link to the returned LS project should be opened from Python
 
         Returns the URL of the created LS workspace

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -322,7 +322,7 @@ class Datasource:
         return self.annotate()
 
     def send_datapoints_to_annotation(self, datapoints: Union[List[Datapoint], QueryResult, List[Dict]],
-                                      open_project=True, ignore_warning=True) -> Optional[str]:
+                                      open_project=True, ignore_warning=False) -> Optional[str]:
         """
         Sends datapoints to annotations in Label Studio
 

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -193,8 +193,10 @@ class QueryResult:
         """
         if type(item) is str:
             return self._datapoint_path_lookup[item]
-        elif type(item) is int or type(item) is slice:
+        elif type(item) is int:
             return self.entries[item]
+        elif type(item) is slice:
+            return QueryResult(_entries=self.entries[item], datasource=self.datasource)
         else:
             raise ValueError(
                 f"Can't lookup datapoint using value {item} of type {type(item)}, "

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -405,11 +405,13 @@ class QueryResult:
 
         return sess
 
-    def annotate(self, open_project: bool) -> Optional[str]:
+    def annotate(self, open_project=True, ignore_warning=True) -> Optional[str]:
         """
         Sends all the datapoints returned in this QueryResult to be annotated in Label Studio on DagsHub.
 
         :param open_project: Whether to automatically open the returned URL in your browser
+        :param ignore_warning: Suppress any non-lethal warnings that require user input
         :return The URL of the created Label Studio workspace
         """
-        return self.datasource.send_datapoints_to_annotation(self.entries, open_project=open_project)
+        return self.datasource.send_datapoints_to_annotation(self.entries,
+                                                             open_project=open_project, ignore_warning=ignore_warning)

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -404,3 +404,12 @@ class QueryResult:
         plugin_server_module.run_plugin_server(sess, self.datasource, self.datasource.source.revision)
 
         return sess
+
+    def annotate(self, open_project: bool) -> Optional[str]:
+        """
+        Sends all the datapoints returned in this QueryResult to be annotated in Label Studio on DagsHub.
+
+        :param open_project: Whether to automatically open the returned URL in your browser
+        :return The URL of the created Label Studio workspace
+        """
+        return self.datasource.send_datapoints_to_annotation(self.entries, open_project=open_project)

--- a/tests/data_engine/test_queryresult.py
+++ b/tests/data_engine/test_queryresult.py
@@ -1,3 +1,8 @@
+import math
+
+from dagshub.data_engine.model.query_result import QueryResult
+
+
 def test_getitem_path(query_result):
     dp = query_result["dp_0"]
     assert dp.datapoint_id == 0
@@ -8,3 +13,12 @@ def test_getitem_index(query_result):
     dp = query_result[0]
     assert dp.datapoint_id == 0
     assert dp.path == "dp_0"
+
+
+def test_getitem_slice_returns_query_result(query_result):
+    qr = query_result[0:len(query_result):2]
+    assert type(qr) == QueryResult
+    assert len(qr) == math.ceil(len(query_result) / 2)
+    for i in range(len(qr)):
+        assert qr[i].datapoint_id is query_result[i * 2].datapoint_id
+


### PR DESCRIPTION
Things in this PR are mostly renaming, some docstring improvements and warning message for large LS project creation.

Renamings:
* datasources.create_from_X -> create
* datasources.get_or_create
* send_X_to_annotations -> annotate
* query_result.annotate()
* `query_result[1:2:3]` returns another QueryResult
